### PR TITLE
Correção de links + ajustes no job markdown-link-check

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,6 +13,7 @@ jobs:
       - run: npx awesome-lint
   markdown-link-check:
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
     - uses: actions/checkout@v4
     - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,9 +13,9 @@ jobs:
       - run: npx awesome-lint
   markdown-link-check:
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
     - uses: actions/checkout@v4
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      continue-on-error: true
       with:
         config-file: markdown-link-check-config.json

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,5 +1,8 @@
 name: checks
-on: pull_request
+on:
+  pull_request:
+  schedule:
+    - cron: '0 0 */20 * *'  # Runs every 20 days
 jobs:
   awesome-lint:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Lista de iniciativas de robótica do Brasil! Sinta-se encorajado a [contribuir](
 - [LAR - Laboratório de Robótica Aplicada Raul Guenther (UFSC)](https://robotica.ufsc.br/)
 - [LARA - Laboratório de Automação e Robótica (UnB)](http://www.lara.unb.br) - [:octocat:](https://github.com/lara-unb)
 - [LARM - Laboratório de Automação e Robótica Móvel (UFSC)](https://larm.ufsc.br/)
-- [LASER - Laboratório Avançado de Sistemas Embarcados e Robótica (UTFPR)](http://laser.dainf.ct.utfpr.edu.br/)
+- [LASER - Laboratório Avançado de Sistemas Embarcados e Robótica (UTFPR)](https://laser.dainf.ct.utfpr.edu.br/)
 - [LASER - Laboratório de Engenharia de Sistemas e Robótica (UFPB)](http://laser.ci.ufpb.br/) - [:octocat:](https://github.com/laser-ufpb)
 - [LCA - Laboratório de Controle Aplicado (IFSP)](https://spo.ifsp.edu.br/lca)
 - [LIRA - Laboratório de Inteligência e Robótica Aplicadas (PUC Rio)](http://www.lira.ele.puc-rio.br)

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Lista de iniciativas de robótica do Brasil! Sinta-se encorajado a [contribuir](
 
 ## Competições e Eventos
 
-- [Competição Brasileira de Robótica (CBR) / Latin American Robotics Competition (LARC) / RoboCup Open](http://www.cbrobotica.org/)
+- [Competição Brasileira de Robótica (CBR) / Latin American Robotics Competition (LARC) / RoboCup Open](https://cbr.robocup.org.br/)
 - [Mostra Nacional de Robótica (MNR)](http://www.mnr.org.br/)
 - [Olimpíada Brasileira de Robótica (OBR)](http://www.obr.org.br/)
 - [Torneio Brasil de Robótica (TBR)](https://www.torneiobrasilderobotica.com.br/)

--- a/markdown-link-check-config.json
+++ b/markdown-link-check-config.json
@@ -2,6 +2,7 @@
     "timeout": "30s",
     "aliveStatusCodes": [
         200,
-        999
+        999,
+        464
     ]
 }


### PR DESCRIPTION
* Corrigir link da CBR
* Corrigir link do lab LASER (http -> https)
* Rodar checks a cada 20 dias
* Flexibilizar o teste de markdown-link-check para não falhar em caso de erro
* Permitir status code 464